### PR TITLE
fix development server

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -200,11 +200,14 @@ module.exports = function (webpackEnv) {
       : isEnvDevelopment && 'cheap-module-source-map',
     // These are the "entry points" to our application.
     // This means they will be the "root" imports that are included in JS bundle.
-    // entry: paths.appIndexJs,
-    entry: {
+    entry: isEnvDevelopment ? paths.appIndexJs : {
       main: [paths.appIndexJs],
       content: ['./src/content.js']
     },
+    // entry: {
+      // main: [paths.appIndexJs],
+      // content: ['./src/content.js']
+    // },
     output: {
       // The build folder.
       path: paths.appBuild,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-// import ReactDOM from 'react-dom';
+import ReactDOM from 'react-dom';
 import logo from './logo.svg';
 import './App.css';
-// import { Main } from './content';
+import { Main } from './content';
 
 function App() {
   return (
@@ -24,10 +24,11 @@ function App() {
     </div>
   );
 }
-// const app = document.createElement('div');
-// app.id = "opennotes-app-root";
 
-// document.body.appendChild(app);
-// ReactDOM.render(<Main />, app);
+const app_render = document.createElement('div');
+app_render.id = "opennotes-app-dev-root";
+
+document.body.appendChild(app_render);
+ReactDOM.render(<Main />, app_render);
 
 export default App;

--- a/src/content.js
+++ b/src/content.js
@@ -95,11 +95,14 @@ app.id = "opennotes-app-root";
 
 app.style.display = 'none';
 
-chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
-    if (request.message === 'clicked_browser_action') {
-        toggle();
-    }
-});
+console.log(`chrome runtime: ${chrome.runtime}`)
+if (chrome.runtime !== undefined) {
+    chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
+        if (request.message === 'clicked_browser_action') {
+            toggle();
+        }
+    });
+}
 
 function toggle() {
     if (app.style.display === 'none') {


### PR DESCRIPTION
starting the development server was stuck due to designating multiple entry points. For now I've changed it to only designate a single entry point for dev builds. This seems to work for running `npm start` and `npm run build` but I'm not sure if it's the "right" way to do things